### PR TITLE
Allow passing options to createContainer function

### DIFF
--- a/with-data.js
+++ b/with-data.js
@@ -1,7 +1,7 @@
 import {createContainer} from 'meteor/react-meteor-data'
 
-export default function (getData) {
+export default function (getMeteorData, opts) {
   return function (ComposedComponent) {
-    return createContainer(getData, ComposedComponent)
+    return createContainer(Object.assign({ getMeteorData }, opts), ComposedComponent)
   }
 }


### PR DESCRIPTION
To disable pure rendering for example.
See meteor/react-packages#193 for more information
