### PR TITLE
Update with-method-data.js

### DIFF
--- a/with-method-data.js
+++ b/with-method-data.js
@@ -14,17 +14,17 @@ export default function (getData) {
 
       componentWillReceiveProps (nextProps) {
         if (!_.isEqual(this.props, nextProps)) {
-          this.fetchData()
+          this.fetchData(nextProps)
         }
       }
 
       componentWillMount () {
-        this.fetchData()
+        this.fetchData(this.props)
       }
 
-      fetchData () {
+      fetchData (props) {
         this.setState({isLoading: true})
-        getData(this.props, (error, response) => {
+        getData(props, (error, response) => {
           this.setState({isLoading: false, response, error})
         })
       }


### PR DESCRIPTION
Was this a bug? 
I was writing a paginated table & ended up with:

``` js
@withData(({}) => {
     console.log( current_page_reactive_var.get() )
     return {
           current_page: current_page_reactive_var.get()
     }
})
@withMethodData((props, callback) => {
    console.log('withMethodData', props) // props was always one step behind the returned state from withData above..
})
```
