### PR TITLE
fix version for react-meteor-data dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -10,7 +10,7 @@ Package.onUse(function (api) {
   api.versionsFrom('1.4.1.1')
   api.use('ecmascript')
   api.use('underscore')
-  api.use('react-meteor-data@0.1.9')
+  api.use('react-meteor-data@0.2.9')
   api.mainModule('main.js')
 })
 


### PR DESCRIPTION
With `0.1.9` I receive the following error:
````
Uncaught TypeError: createContainer is not a function
````